### PR TITLE
fix: redirect legacy un-prefixed URLs (e.g. /about-us) to /es

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { defaultLocale, locales } from "@/i18n/config";
+
+// Static export emits this as /404.html, which GitHub Pages serves for any
+// unmatched path. Legacy links (e.g. Instagram posts) point at un-prefixed
+// URLs like /about-us or /news/<slug> that used to exist before locale
+// routing. Here we redirect those to the default locale (/es/...), preserving
+// the path, query and hash. Paths already under /es or /en (a genuine 404) or
+// Next asset paths are left alone, so there's no redirect loop.
+export default function NotFound() {
+  useEffect(() => {
+    const { pathname, search, hash } = window.location;
+    const segment = pathname.split("/")[1] ?? "";
+    const isLocalePrefixed = (locales as readonly string[]).includes(segment);
+    const isAsset = segment === "_next" || pathname.includes(".");
+
+    if (segment && !isLocalePrefixed && !isAsset) {
+      window.location.replace(`/${defaultLocale}${pathname}${search}${hash}`);
+    }
+  }, []);
+
+  return (
+    <main style={{ padding: "3rem 1.5rem", textAlign: "center" }}>
+      <h1>404</h1>
+      <p>
+        <a href={`/${defaultLocale}`}>OAN International</a>
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Problem
Old links — like the Instagram posts pointing at pre-i18n URLs (`/about-us`, `/news/<slug>`, `/projects`, …) — now **404**, because after the language migration every route lives under `/es` or `/en`. The root `/` already redirects, but deep paths didn't.

## Fix
A custom not-found page (`src/app/not-found.tsx`) that static export emits as **`/404.html`**. GitHub Pages serves that file for any unmatched path, and its script redirects un-prefixed paths to the default locale, **preserving the path, query string and hash**:
- `/about-us` → `/es/about-us`
- `/about-us?section=team` → `/es/about-us?section=team`
- `/news/10-aniversario` → `/es/news/10-aniversario`

Paths already under `/es` or `/en` (a genuine 404) and Next asset paths (`/_next/…`) are left alone — **no redirect loop**. The existing `/` → `/es` redirect is untouched.

Why this approach: GitHub Pages has no server-side redirects (no `_redirects`/`.htaccess`), so the standard solution is the JS-based `404.html` fallback. It's generic — it covers every old path without enumerating routes.

## Verification (static serve + browser)
- `/about-us?section=team` → `/es/about-us?section=team` (query preserved) ✓
- `/news/10-aniversario` → `/es/news/10-aniversario` (legacy blog link) ✓
- `/es/does-not-exist` → shows the 404, no loop ✓
- No console errors; `npm run lint` clean; `npm run build` passes (70 pages)

## Note
Because this is a client-side redirect, the 404 response carries a 404 status for crawlers (fine for the goal — real visitors from Instagram land on the right page). Independent of PR #54; targets `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)