### PR TITLE
fix(i18n): language switcher stuck on French

### DIFF
--- a/src/components/header/header.component.tsx
+++ b/src/components/header/header.component.tsx
@@ -100,7 +100,10 @@ export default function Header({ locale }: { locale: Locale }) {
       return;
     }
     const search = typeof window !== "undefined" ? window.location.search : "";
-    const nextPath = pathname.replace(/^\/(es|en)/, `/${target}`);
+    // Swap whichever locale prefix is present. Built from `locales` so adding a
+    // language (e.g. fr) doesn't silently break the switcher.
+    const localePrefix = new RegExp(`^/(${locales.join("|")})(?=/|$)`);
+    const nextPath = pathname.replace(localePrefix, `/${target}`);
     router.push(nextPath + search);
     setIsMobileNavBarOpen(false);
   };


### PR DESCRIPTION
## Bug
Once you switched to **French**, you couldn't switch back — clicking ES/EN did nothing.

## Cause
The switcher swapped the URL's locale prefix with a hardcoded regex:
```js
pathname.replace(/^\/(es|en)/, `/${target}`)
```
It was never updated when French was added, so on a `/fr/...` page the regex doesn't match, `nextPath` stays `/fr/...`, and `router.push` navigates to the same URL — no change.

## Fix
Build the prefix regex from the `locales` list so it always covers every language (and can't silently go stale when another is added):
```js
new RegExp(`^/(${locales.join("|")})(?=/|$)`)
```

## Verification (browser)
Full **FR → ES → EN → FR** round-trip works; the `?section=` deep-link query is preserved; `lang` updates each time; no console errors. Build + lint green.

Targets `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)