### PR TITLE
Release: develop → main (language-switcher fix)

### DIFF
--- a/src/components/header/header.component.tsx
+++ b/src/components/header/header.component.tsx
@@ -100,7 +100,10 @@ export default function Header({ locale }: { locale: Locale }) {
       return;
     }
     const search = typeof window !== "undefined" ? window.location.search : "";
-    const nextPath = pathname.replace(/^\/(es|en)/, `/${target}`);
+    // Swap whichever locale prefix is present. Built from `locales` so adding a
+    // language (e.g. fr) doesn't silently break the switcher.
+    const localePrefix = new RegExp(`^/(${locales.join("|")})(?=/|$)`);
+    const nextPath = pathname.replace(localePrefix, `/${target}`);
     router.push(nextPath + search);
     setIsMobileNavBarOpen(false);
   };


### PR DESCRIPTION
Publishes the language-switcher fix (#60) on top of French support, the flat single-language blog, SEO/perf/a11y, and the legacy-URL redirect.